### PR TITLE
feat: add plaintext QR code display for hardware wallet scanning

### DIFF
--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -762,6 +762,7 @@ export function EncryptorTool() {
                       <div className="flex flex-col items-center gap-4 py-4">
                         {selectedDecryptText.length <= QR_MAX_CHARS ? (
                           <>
+                            <p style={{wordBreak: 'break-all', fontSize: '12px', color: 'gray'}}>{selectedDecryptText}</p>
                             <QRCode value={selectedDecryptText} size={256} />
                             <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
                               <QRCodeCanvas value={selectedDecryptText} size={900} />

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -762,17 +762,14 @@ export function EncryptorTool() {
                       <div className="flex flex-col items-center gap-4 py-4">
                         {selectedDecryptText.length <= QR_MAX_CHARS ? (
                           <>
-                            <>
-                              <QRCode value={selectedDecryptText} size={256} />
-                              <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
-                                <QRCodeCanvas value={selectedDecryptText} size={900} />
-                              </div>
-                              <Button onClick={handleDownloadDecryptQrCode}>
-                                <Download className="mr-2 h-4 w-4" />
-                                Download PNG (300 DPI)
-                              </Button>
-                            </>
-                            <p style={{wordBreak: 'break-all', fontSize: '12px', color: 'gray'}}>{selectedDecryptText}</p>
+                            <QRCode value={selectedDecryptText} size={256} />
+                            <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
+                              <QRCodeCanvas value={selectedDecryptText} size={900} />
+                            </div>
+                            <Button onClick={handleDownloadDecryptQrCode}>
+                              <Download className="mr-2 h-4 w-4" />
+                              Download PNG (300 DPI)
+                            </Button>
                           </>
                         ) : (
                           <div className="text-sm text-yellow-400 p-3 bg-yellow-900/20 rounded-md text-center">
@@ -786,6 +783,7 @@ export function EncryptorTool() {
                 )}
               </div>
             </div>
+            <p style={{fontSize: '11px', color: 'red', wordBreak: 'break-all'}}>{selectedDecryptText}</p>
           </div>
         )}
 

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -187,6 +187,7 @@ export function EncryptorTool() {
   const [passwordIsStrong, setPasswordIsStrong] = useState(false);
   const [isCryptoAvailable, setIsCryptoAvailable] = useState(true);
   const [isQrModalOpen, setIsQrModalOpen] = useState(false);
+  const [isDecryptQrModalOpen, setIsDecryptQrModalOpen] = useState(false);
   const qrCodeRef = useRef<HTMLDivElement>(null);
   const clipboardTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { toast } = useToast();
@@ -363,6 +364,7 @@ export function EncryptorTool() {
 
   // High-res QR download: renders at 900px (≈3" at 300 DPI) with quiet zone padding
   const hiResQrRef = useRef<HTMLDivElement>(null);
+  const hiResDecryptQrRef = useRef<HTMLDivElement>(null);
 
   const handleDownloadQrCode = useCallback(() => {
     if (!hiResQrRef.current) return;
@@ -394,6 +396,29 @@ export function EncryptorTool() {
     a.click();
     document.body.removeChild(a);
 
+    toast({ title: "QR Code downloaded", description: "High-resolution (300 DPI / 1020×1020px)" });
+  }, [toast]);
+
+  const handleDownloadDecryptQrCode = useCallback(() => {
+    if (!hiResDecryptQrRef.current) return;
+    const hiResCanvas = hiResDecryptQrRef.current.querySelector('canvas');
+    if (!hiResCanvas) return;
+    const PADDING = 60;
+    const exportCanvas = document.createElement('canvas');
+    const ctx = exportCanvas.getContext('2d');
+    if (!ctx) return;
+    exportCanvas.width = hiResCanvas.width + PADDING * 2;
+    exportCanvas.height = hiResCanvas.height + PADDING * 2;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, exportCanvas.width, exportCanvas.height);
+    ctx.drawImage(hiResCanvas, PADDING, PADDING);
+    const pngUrl = exportCanvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
+    const a = document.createElement("a");
+    a.href = pngUrl;
+    a.download = "decrypted-qr.png";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
     toast({ title: "QR Code downloaded", description: "High-resolution (300 DPI / 1020×1020px)" });
   }, [toast]);
 
@@ -717,6 +742,42 @@ export function EncryptorTool() {
                       </DialogContent>
                     </Dialog>
                   )}
+                {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
+                  <Dialog open={isDecryptQrModalOpen} onOpenChange={setIsDecryptQrModalOpen}>
+                    <DialogTrigger asChild>
+                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2">
+                        <QrCode />
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent>
+                      <DialogHeader>
+                        <DialogTitle>Plaintext QR Code</DialogTitle>
+                        <DialogDescription>
+                          Scan this code to transfer the decrypted text to your hardware wallet.
+                        </DialogDescription>
+                      </DialogHeader>
+                      <div className="flex flex-col items-center gap-4 py-4">
+                        {outputText.length <= QR_MAX_CHARS ? (
+                          <>
+                            <QRCode value={outputText} size={256} />
+                            <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
+                              <QRCodeCanvas value={outputText} size={900} />
+                            </div>
+                            <Button onClick={handleDownloadDecryptQrCode}>
+                              <Download className="mr-2 h-4 w-4" />
+                              Download PNG (300 DPI)
+                            </Button>
+                          </>
+                        ) : (
+                          <div className="text-sm text-yellow-400 p-3 bg-yellow-900/20 rounded-md text-center">
+                            <p className="font-medium">QR code unavailable</p>
+                            <p className="mt-1">Output is {outputText.length.toLocaleString()} characters, which exceeds the QR code capacity of {QR_MAX_CHARS.toLocaleString()} characters. Use the copy button instead.</p>
+                          </div>
+                        )}
+                      </div>
+                    </DialogContent>
+                  </Dialog>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -366,6 +366,7 @@ export function EncryptorTool() {
   // High-res QR download: renders at 900px (≈3" at 300 DPI) with quiet zone padding
   const hiResQrRef = useRef<HTMLDivElement>(null);
   const hiResDecryptQrRef = useRef<HTMLDivElement>(null);
+  const outputTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleDownloadQrCode = useCallback(() => {
     if (!hiResQrRef.current) return;
@@ -688,6 +689,7 @@ export function EncryptorTool() {
             <div className="relative">
               <Textarea
                 id="output-text"
+                ref={outputTextareaRef}
                 value={outputText}
                 readOnly
                 rows={5}
@@ -695,8 +697,6 @@ export function EncryptorTool() {
                   "pr-12",
                   mode === 'decrypt' && inputType === 'text' && !showDecryptedText && "blur-sm"
                 )}
-                onMouseUp={() => { const ta = document.getElementById('output-text') as HTMLTextAreaElement; if (ta) { const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd); setSelectedDecryptText(sel || outputText); } }}
-                onKeyUp={() => { const ta = document.getElementById('output-text') as HTMLTextAreaElement; if (ta) { const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd); setSelectedDecryptText(sel || outputText); } }}
               />
               <div className="absolute right-1 top-1 flex flex-col items-center">
                  {mode === 'decrypt' && inputType === 'text' && (
@@ -746,7 +746,14 @@ export function EncryptorTool() {
                     </Dialog>
                   )}
                 {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
-                  <Dialog open={isDecryptQrModalOpen} onOpenChange={setIsDecryptQrModalOpen}>
+                  <Dialog onOpenChange={(open) => {
+                    if (open && outputTextareaRef.current) {
+                      const ta = outputTextareaRef.current;
+                      const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd);
+                      setSelectedDecryptText(sel || outputText);
+                    }
+                    setIsDecryptQrModalOpen(open);
+                  }}>
                     <DialogTrigger asChild>
                       <Button type="button" variant="ghost" size="icon" className="h-auto p-2">
                         <QrCode />

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -790,7 +790,6 @@ export function EncryptorTool() {
                 )}
               </div>
             </div>
-            <p style={{fontSize: '11px', color: 'red', wordBreak: 'break-all'}}>{selectedDecryptText}</p>
           </div>
         )}
 

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -762,15 +762,17 @@ export function EncryptorTool() {
                       <div className="flex flex-col items-center gap-4 py-4">
                         {selectedDecryptText.length <= QR_MAX_CHARS ? (
                           <>
+                            <>
+                              <QRCode value={selectedDecryptText} size={256} />
+                              <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
+                                <QRCodeCanvas value={selectedDecryptText} size={900} />
+                              </div>
+                              <Button onClick={handleDownloadDecryptQrCode}>
+                                <Download className="mr-2 h-4 w-4" />
+                                Download PNG (300 DPI)
+                              </Button>
+                            </>
                             <p style={{wordBreak: 'break-all', fontSize: '12px', color: 'gray'}}>{selectedDecryptText}</p>
-                            <QRCode value={selectedDecryptText} size={256} />
-                            <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
-                              <QRCodeCanvas value={selectedDecryptText} size={900} />
-                            </div>
-                            <Button onClick={handleDownloadDecryptQrCode}>
-                              <Download className="mr-2 h-4 w-4" />
-                              Download PNG (300 DPI)
-                            </Button>
                           </>
                         ) : (
                           <div className="text-sm text-yellow-400 p-3 bg-yellow-900/20 rounded-md text-center">

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -189,7 +189,6 @@ export function EncryptorTool() {
   const [isQrModalOpen, setIsQrModalOpen] = useState(false);
   const [isDecryptQrModalOpen, setIsDecryptQrModalOpen] = useState(false);
   const [selectedDecryptText, setSelectedDecryptText] = useState('');
-  const qrCodeRef = useRef<HTMLDivElement>(null);
   const clipboardTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { toast } = useToast();
 
@@ -239,6 +238,8 @@ export function EncryptorTool() {
     setOutputText('');
     setShowDecryptedText(false);
     setInputType('file');
+    setSelectedDecryptText('');
+    setIsDecryptQrModalOpen(false);
   }, []);
 
   const handleModeChange = useCallback((newMode: string) => {
@@ -719,7 +720,7 @@ export function EncryptorTool() {
                             Scan this code to transfer the encrypted text.
                           </DialogDescription>
                         </DialogHeader>
-                        <div className="flex flex-col items-center gap-4 py-4" ref={qrCodeRef}>
+                        <div className="flex flex-col items-center gap-4 py-4">
                            {outputText.length <= QR_MAX_CHARS ? (
                              <>
                                {/* Preview QR (256px for the dialog) */}

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -748,7 +748,7 @@ export function EncryptorTool() {
                 {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
                   <Dialog open={isDecryptQrModalOpen} onOpenChange={setIsDecryptQrModalOpen}>
                     <DialogTrigger asChild>
-                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2" onClick={() => { const ta = document.getElementById('output-text') as HTMLTextAreaElement; if (ta) { const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd); setSelectedDecryptText(sel || outputText); } }}>
+                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2" onMouseDown={(e) => { e.preventDefault(); const ta = document.getElementById('output-text') as HTMLTextAreaElement; if (ta) { const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd); setSelectedDecryptText(sel || outputText); } }}>
                         <QrCode />
                       </Button>
                     </DialogTrigger>

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -746,7 +746,7 @@ export function EncryptorTool() {
                 {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
                   <Dialog open={isDecryptQrModalOpen} onOpenChange={setIsDecryptQrModalOpen}>
                     <DialogTrigger asChild>
-                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2">
+                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2" disabled={!selectedDecryptText}>
                         <QrCode />
                       </Button>
                     </DialogTrigger>

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -366,8 +366,6 @@ export function EncryptorTool() {
 
   // High-res QR download: renders at 900px (≈3" at 300 DPI) with quiet zone padding
   const hiResQrRef = useRef<HTMLDivElement>(null);
-  const hiResDecryptQrRef = useRef<HTMLDivElement>(null);
-
   const handleDownloadQrCode = useCallback(() => {
     if (!hiResQrRef.current) return;
     const hiResCanvas = hiResQrRef.current.querySelector('canvas');
@@ -398,29 +396,6 @@ export function EncryptorTool() {
     a.click();
     document.body.removeChild(a);
 
-    toast({ title: "QR Code downloaded", description: "High-resolution (300 DPI / 1020×1020px)" });
-  }, [toast]);
-
-  const handleDownloadDecryptQrCode = useCallback(() => {
-    if (!hiResDecryptQrRef.current) return;
-    const hiResCanvas = hiResDecryptQrRef.current.querySelector('canvas');
-    if (!hiResCanvas) return;
-    const PADDING = 60;
-    const exportCanvas = document.createElement('canvas');
-    const ctx = exportCanvas.getContext('2d');
-    if (!ctx) return;
-    exportCanvas.width = hiResCanvas.width + PADDING * 2;
-    exportCanvas.height = hiResCanvas.height + PADDING * 2;
-    ctx.fillStyle = '#ffffff';
-    ctx.fillRect(0, 0, exportCanvas.width, exportCanvas.height);
-    ctx.drawImage(hiResCanvas, PADDING, PADDING);
-    const pngUrl = exportCanvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
-    const a = document.createElement("a");
-    a.href = pngUrl;
-    a.download = "decrypted-qr.png";
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
     toast({ title: "QR Code downloaded", description: "High-resolution (300 DPI / 1020×1020px)" });
   }, [toast]);
 
@@ -774,13 +749,6 @@ export function EncryptorTool() {
                         {(selectedDecryptText || outputText).length <= QR_MAX_CHARS ? (
                           <>
                             <QRCode value={selectedDecryptText || outputText} size={256} />
-                            <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
-                              <QRCodeCanvas value={selectedDecryptText || outputText} size={900} />
-                            </div>
-                            <Button onClick={handleDownloadDecryptQrCode}>
-                              <Download className="mr-2 h-4 w-4" />
-                              Download PNG (300 DPI)
-                            </Button>
                           </>
                         ) : (
                           <div className="text-sm text-yellow-400 p-3 bg-yellow-900/20 rounded-md text-center">

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -743,7 +743,19 @@ export function EncryptorTool() {
                       </DialogContent>
                     </Dialog>
                   )}
-                {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
+              </div>
+            </div>
+            {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
+              <div className="space-y-1">
+                <Label htmlFor="qr-text-input" className="text-xs text-muted-foreground">QR text (paste what you want to encode, or leave empty to use full output)</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    id="qr-text-input"
+                    value={selectedDecryptText}
+                    onChange={(e) => setSelectedDecryptText(e.target.value)}
+                    placeholder="Paste seed words or passphrase here..."
+                    className="text-xs"
+                  />
                   <Dialog open={isDecryptQrModalOpen} onOpenChange={setIsDecryptQrModalOpen}>
                     <DialogTrigger asChild>
                       <Button type="button" variant="ghost" size="icon" className="h-auto p-2" disabled={!selectedDecryptText}>
@@ -778,19 +790,7 @@ export function EncryptorTool() {
                       </div>
                     </DialogContent>
                   </Dialog>
-                )}
-              </div>
-            </div>
-            {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
-              <div className="space-y-1">
-                <Label htmlFor="qr-text-input" className="text-xs text-muted-foreground">QR text (paste what you want to encode, or leave empty to use full output)</Label>
-                <Input
-                  id="qr-text-input"
-                  value={selectedDecryptText}
-                  onChange={(e) => setSelectedDecryptText(e.target.value)}
-                  placeholder="Paste seed words or passphrase here..."
-                  className="text-xs"
-                />
+                </div>
               </div>
             )}
           </div>

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -188,6 +188,7 @@ export function EncryptorTool() {
   const [isCryptoAvailable, setIsCryptoAvailable] = useState(true);
   const [isQrModalOpen, setIsQrModalOpen] = useState(false);
   const [isDecryptQrModalOpen, setIsDecryptQrModalOpen] = useState(false);
+  const [selectedDecryptText, setSelectedDecryptText] = useState('');
   const qrCodeRef = useRef<HTMLDivElement>(null);
   const clipboardTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { toast } = useToast();
@@ -694,6 +695,8 @@ export function EncryptorTool() {
                   "pr-12",
                   mode === 'decrypt' && inputType === 'text' && !showDecryptedText && "blur-sm"
                 )}
+                onMouseUp={() => { const ta = document.getElementById('output-text') as HTMLTextAreaElement; if (ta) { const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd); setSelectedDecryptText(sel || outputText); } }}
+                onKeyUp={() => { const ta = document.getElementById('output-text') as HTMLTextAreaElement; if (ta) { const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd); setSelectedDecryptText(sel || outputText); } }}
               />
               <div className="absolute right-1 top-1 flex flex-col items-center">
                  {mode === 'decrypt' && inputType === 'text' && (
@@ -745,7 +748,7 @@ export function EncryptorTool() {
                 {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
                   <Dialog open={isDecryptQrModalOpen} onOpenChange={setIsDecryptQrModalOpen}>
                     <DialogTrigger asChild>
-                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2">
+                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2" onClick={() => { const ta = document.getElementById('output-text') as HTMLTextAreaElement; if (ta) { const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd); setSelectedDecryptText(sel || outputText); } }}>
                         <QrCode />
                       </Button>
                     </DialogTrigger>
@@ -757,11 +760,11 @@ export function EncryptorTool() {
                         </DialogDescription>
                       </DialogHeader>
                       <div className="flex flex-col items-center gap-4 py-4">
-                        {outputText.length <= QR_MAX_CHARS ? (
+                        {selectedDecryptText.length <= QR_MAX_CHARS ? (
                           <>
-                            <QRCode value={outputText} size={256} />
+                            <QRCode value={selectedDecryptText} size={256} />
                             <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
-                              <QRCodeCanvas value={outputText} size={900} />
+                              <QRCodeCanvas value={selectedDecryptText} size={900} />
                             </div>
                             <Button onClick={handleDownloadDecryptQrCode}>
                               <Download className="mr-2 h-4 w-4" />
@@ -771,7 +774,7 @@ export function EncryptorTool() {
                         ) : (
                           <div className="text-sm text-yellow-400 p-3 bg-yellow-900/20 rounded-md text-center">
                             <p className="font-medium">QR code unavailable</p>
-                            <p className="mt-1">Output is {outputText.length.toLocaleString()} characters, which exceeds the QR code capacity of {QR_MAX_CHARS.toLocaleString()} characters. Use the copy button instead.</p>
+                            <p className="mt-1">Output is {selectedDecryptText.length.toLocaleString()} characters, which exceeds the QR code capacity of {QR_MAX_CHARS.toLocaleString()} characters. Use the copy button instead.</p>
                           </div>
                         )}
                       </div>

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -366,7 +366,6 @@ export function EncryptorTool() {
   // High-res QR download: renders at 900px (≈3" at 300 DPI) with quiet zone padding
   const hiResQrRef = useRef<HTMLDivElement>(null);
   const hiResDecryptQrRef = useRef<HTMLDivElement>(null);
-  const outputTextareaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleDownloadQrCode = useCallback(() => {
     if (!hiResQrRef.current) return;
@@ -689,7 +688,6 @@ export function EncryptorTool() {
             <div className="relative">
               <Textarea
                 id="output-text"
-                ref={outputTextareaRef}
                 value={outputText}
                 readOnly
                 rows={5}
@@ -746,14 +744,7 @@ export function EncryptorTool() {
                     </Dialog>
                   )}
                 {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
-                  <Dialog onOpenChange={(open) => {
-                    if (open && outputTextareaRef.current) {
-                      const ta = outputTextareaRef.current;
-                      const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd);
-                      setSelectedDecryptText(sel || outputText);
-                    }
-                    setIsDecryptQrModalOpen(open);
-                  }}>
+                  <Dialog open={isDecryptQrModalOpen} onOpenChange={setIsDecryptQrModalOpen}>
                     <DialogTrigger asChild>
                       <Button type="button" variant="ghost" size="icon" className="h-auto p-2">
                         <QrCode />
@@ -767,11 +758,11 @@ export function EncryptorTool() {
                         </DialogDescription>
                       </DialogHeader>
                       <div className="flex flex-col items-center gap-4 py-4">
-                        {selectedDecryptText.length <= QR_MAX_CHARS ? (
+                        {(selectedDecryptText || outputText).length <= QR_MAX_CHARS ? (
                           <>
-                            <QRCode value={selectedDecryptText} size={256} />
+                            <QRCode value={selectedDecryptText || outputText} size={256} />
                             <div ref={hiResDecryptQrRef} style={{ position: 'absolute', left: '-9999px', top: '-9999px' }}>
-                              <QRCodeCanvas value={selectedDecryptText} size={900} />
+                              <QRCodeCanvas value={selectedDecryptText || outputText} size={900} />
                             </div>
                             <Button onClick={handleDownloadDecryptQrCode}>
                               <Download className="mr-2 h-4 w-4" />
@@ -781,7 +772,7 @@ export function EncryptorTool() {
                         ) : (
                           <div className="text-sm text-yellow-400 p-3 bg-yellow-900/20 rounded-md text-center">
                             <p className="font-medium">QR code unavailable</p>
-                            <p className="mt-1">Output is {selectedDecryptText.length.toLocaleString()} characters, which exceeds the QR code capacity of {QR_MAX_CHARS.toLocaleString()} characters. Use the copy button instead.</p>
+                            <p className="mt-1">Output is {(selectedDecryptText || outputText).length.toLocaleString()} characters, which exceeds the QR code capacity of {QR_MAX_CHARS.toLocaleString()} characters. Use the copy button instead.</p>
                           </div>
                         )}
                       </div>
@@ -790,6 +781,18 @@ export function EncryptorTool() {
                 )}
               </div>
             </div>
+            {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
+              <div className="space-y-1">
+                <Label htmlFor="qr-text-input" className="text-xs text-muted-foreground">QR text (paste what you want to encode, or leave empty to use full output)</Label>
+                <Input
+                  id="qr-text-input"
+                  value={selectedDecryptText}
+                  onChange={(e) => setSelectedDecryptText(e.target.value)}
+                  placeholder="Paste seed words or passphrase here..."
+                  className="text-xs"
+                />
+              </div>
+            )}
           </div>
         )}
 

--- a/src/components/encryptor-tool.tsx
+++ b/src/components/encryptor-tool.tsx
@@ -748,7 +748,7 @@ export function EncryptorTool() {
                 {mode === 'decrypt' && inputType === 'text' && showDecryptedText && (
                   <Dialog open={isDecryptQrModalOpen} onOpenChange={setIsDecryptQrModalOpen}>
                     <DialogTrigger asChild>
-                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2" onMouseDown={(e) => { e.preventDefault(); const ta = document.getElementById('output-text') as HTMLTextAreaElement; if (ta) { const sel = ta.value.substring(ta.selectionStart, ta.selectionEnd); setSelectedDecryptText(sel || outputText); } }}>
+                      <Button type="button" variant="ghost" size="icon" className="h-auto p-2">
                         <QrCode />
                       </Button>
                     </DialogTrigger>


### PR DESCRIPTION
## Summary
Adds a QR code display feature for decrypted plaintext output, designed for transferring seed phrases and passphrases to hardware wallets such as the Coldcard Q via QR scan.

## Behaviour
- After decrypting text and revealing it, a QR text input field appears below the result
- The user pastes the specific text they want to encode (seed words, passphrase, or any portion of the output)
- The QR button next to the input field is disabled until the user has entered text, preventing accidental misuse
- Clicking the QR button opens a dialog with a 256px scannable QR code
- No download option is provided for plaintext QR codes — intentionally omitted as a security measure to avoid saving sensitive plaintext to disk
- If the input exceeds 2,953 characters (QR capacity limit), a clear message is shown instead
- State resets cleanly when switching between encrypt/decrypt modes

## Testing
- Tested across Chrome, Edge, and Firefox
- Confirmed working end-to-end with a Coldcard Q hardware wallet — both seed phrase and passphrase QR scans produced correct fingerprints

## Implementation
- Only touches the display layer — no changes to the cryptographic core
- Reuses existing `QRCode`, `QR_MAX_CHARS`, and `Dialog` components already in the project