### PR TITLE
Run npm ci with --ignore-scripts in the build job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,10 @@ jobs:
           node-version: 20
           cache: npm
 
-      - run: npm ci
+      # --ignore-scripts: no package in the lockfile declares an install
+      # script, so this costs nothing today and stops a compromised
+      # transitive dependency from executing code in the build job tomorrow.
+      - run: npm ci --ignore-scripts
       - run: npm run build
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
`deploy.yml` already carries a comment explaining that the build job deliberately holds no writable token, because `npm ci` runs untrusted transitive install scripts:

> No workflow-level permissions — each job requests only what it needs, so the build job (which runs untrusted transitive install scripts via `npm ci`) never holds a token that can write Pages or mint an OIDC identity.

No package in the lockfile actually declares an install script — zero entries with `hasInstallScript` across all 173 packages. So disabling them costs nothing today and removes the execution path entirely if a transitive dependency adds one later.

The crypto-regression workflow already avoids `npm ci` for the same stated reason, so this brings the two workflows in line.

Verified: `npm ci --ignore-scripts` followed by `tsc --noEmit`, both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
